### PR TITLE
Mission 5.1 (Problème 1) : Déplacement du login:pwd API dans App.config

### DIFF
--- a/MediaTekDocuments/App.config
+++ b/MediaTekDocuments/App.config
@@ -5,6 +5,10 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+	<connectionStrings>
+		<add name="MediaTekDocuments.Properties.Settings.apiAuthentification"
+             connectionString="admin:adminpwd" />
+	</connectionStrings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/MediaTekDocuments/dal/Access.cs
+++ b/MediaTekDocuments/dal/Access.cs
@@ -43,7 +43,11 @@ namespace MediaTekDocuments.dal
         /// méthode HTTP pour delete
         /// </summary>
         private const string DELETE = "DELETE";
-        
+        /// <summary>
+        /// nom de connexion à la bdd
+        /// </summary>
+        private static readonly string connectionName = "MediaTekDocuments.Properties.Settings.apiAuthentification";
+
 
         /// <summary>
         /// Méthode privée pour créer un singleton
@@ -54,7 +58,7 @@ namespace MediaTekDocuments.dal
             String authenticationString;
             try
             {
-                authenticationString = "admin:adminpwd";
+                authenticationString = GetAuthenticationString(connectionName);
                 api = ApiRest.GetInstance(uriApi, authenticationString);
             }
             catch (Exception e)
@@ -62,6 +66,19 @@ namespace MediaTekDocuments.dal
                 Console.WriteLine(e.Message);
                 Environment.Exit(0);
             }
+        }
+
+
+        /// <summary>
+        /// Récupère la chaîne d'authentification depuis App.config
+        /// </summary>
+        private static string GetAuthenticationString(string name)
+        {
+            string returnValue = null;
+            ConnectionStringSettings settings = ConfigurationManager.ConnectionStrings[name];
+            if (settings != null)
+                returnValue = settings.ConnectionString;
+            return returnValue;
         }
 
         /// <summary>


### PR DESCRIPTION
Le couple login:pwd de l'API était écrit en dur dans le constructeur de la classe Access. Il a été déplacé dans App.config et est maintenant récupéré via ConfigurationManager. Ainsi, les informations de connexion ne sont plus visibles directement dans le code source.